### PR TITLE
Improve vimvim challenge by 2 strokes

### DIFF
--- a/51103ad8041832000200003f/cmd
+++ b/51103ad8041832000200003f/cmd
@@ -1,1 +1,1 @@
-O<space>v<space><esc>jo<space>m<space><esc>%<a-s>Hy21P2<a-space>gld%y6p,q
+O<space>v<space><down><ret><space>m<space><esc>%<a-s>Hd22p2<a-space>hd%y6p,q


### PR DESCRIPTION
Not sure why after `22p` the cursors are at EOL. I would've expected them to be at the start of the line