### PR TITLE
Adding practice script

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -17,3 +17,5 @@ the vim ZZ binding.
 * The `vgscore.sh` script retrieves the current top scores from vimgolf website,
   run it first so that `golf.sh` can display a comparison.
 * The `vgdl.sh` script retrieves a challenge from the vimgolf.com website
+* The `practice.sh` script takes the index of a challenge (as shown by ls), 
+  outputs the solution, and opens the input file in kakoune.

--- a/practice.sh
+++ b/practice.sh
@@ -1,0 +1,6 @@
+#/bin/bash
+
+n=$1
+example=$(ls | head -n$n | tail -n1)
+cat $example/cmd
+tmux split-window -h kak $(pwd)/$example/in


### PR DESCRIPTION
I added a simple script to make walking through the examples and typing them out manually for learning purposes (hooray for `m`!). The main drawback I can see is that it relies on tmux, but it seems to be a pretty safe assumption for kakoune users.

Usage: `./practice.sh n` where n is the index as shown by `ls` of the desired challenge.