### PR TITLE
Score improvements for some challenges & eliminate external commands

### DIFF
--- a/4d1aaf2fb11838287d000036/cmd
+++ b/4d1aaf2fb11838287d000036/cmd
@@ -1,1 +1,1 @@
-<a-l>|rev<ret>,q
+<a-l>QZ<a-S><a-)>zHHQ12q,q

--- a/4fc9d767d3a0d4000100000e/cmd
+++ b/4fc9d767d3a0d4000100000e/cmd
@@ -1,1 +1,1 @@
-%sa<ret><a-l>a;<esc>,q
+%<a-s>_a;<esc>,q

--- a/50048db8cdc4060002000004/cmd
+++ b/50048db8cdc4060002000004/cmd
@@ -1,1 +1,1 @@
-%<a-s><a-S>i"<esc><a-J>i,<home>[<space><end><space>]<esc>,q
+%<a-s><a-S>i"<a-;><a-J>,<home>[<space><end><space>]<esc>,q

--- a/50ad2cb165b8db0002000029/cmd
+++ b/50ad2cb165b8db0002000029/cmd
@@ -1,1 +1,1 @@
-%S\n\n<ret><a-j>Xs ><ret>d,q
+%S\n\n<ret><a-j>s ><ret>d,q

--- a/5325695c6092800002072d06/cmd
+++ b/5325695c6092800002072d06/cmd
@@ -1,1 +1,1 @@
-7wT<space>yCR2C5Ws<space>+<ret>&,q
+f-<a-e>yCR2C5Ws<space>+<ret>&,q

--- a/5518cd2bfb03aa1d9402a6a3/cmd
+++ b/5518cd2bfb03aa1d9402a6a3/cmd
@@ -1,1 +1,1 @@
-%s<lt>x<ret>CWLy<a-l>pla/<esc>,q
+/x<ret>NCmy<a-l>pla/<esc>,q

--- a/5526aef5814f89118e00f23c/cmd
+++ b/5526aef5814f89118e00f23c/cmd
@@ -1,1 +1,1 @@
-%sC<ret>bisch<esc>;~,q
+ms<space><ret>l~isch<esc>,q

--- a/553b97364ba96c319d0296eb/cmd
+++ b/553b97364ba96c319d0296eb/cmd
@@ -1,1 +1,1 @@
-<a-l>s[-+*/=]<ret>i<space><right><space><esc>,q
+<a-l>s[*-/=]<ret>i<space><right><space><esc>,q

--- a/55b18bbea9c2c30d04000001/cmd
+++ b/55b18bbea9c2c30d04000001/cmd
@@ -1,1 +1,1 @@
-6xyPhr1yP3hr73joNew text.<ret><esc>,q
+6xyPhr1yP3hr73joNew t<c-n><c-n>.<ret><esc>,q

--- a/55f9720b4a665c2acf0008c8/cmd
+++ b/55f9720b4a665c2acf0008c8/cmd
@@ -1,1 +1,1 @@
-%<a-s>yp`s[ .(:,]+<ret>c-<end>:<down><home>name: "<end>"<esc><gt>ggfô;rofé;ref);dfï;rifâ;ra,q
+%<a-s>yp`s\W+<ret><a-K>$<ret>c-<end>:<down><home>name: "<end>"<esc><gt>ggfô;rofé;reeldfï;rifâ;ra,q

--- a/55ff7ea45a2b52043e06dee2/cmd
+++ b/55ff7ea45a2b52043e06dee2/cmd
@@ -1,1 +1,1 @@
-%sY_VAR_[\w_]<plus><ret>`s_<ret>d~,q
+%sY_VAR_\w+<ret>`s_<ret>d~,q

--- a/56d70389bbbe462aff01d42a/cmd
+++ b/56d70389bbbe462aff01d42a/cmd
@@ -1,1 +1,1 @@
-xs[ra]\b<ret><a-t>=<a-)>,q
+xS<space><ret>h<a-t>=<a-)>,q

--- a/56e69da07b3d84520a000001/cmd
+++ b/56e69da07b3d84520a000001/cmd
@@ -1,1 +1,1 @@
-<a-l>y|rev<ret><a-l>p,q
+<a-l>ypQZ<a-S><a-)>zHHQ14q,q

--- a/57343555fd77ad227900df4a/cmd
+++ b/57343555fd77ad227900df4a/cmd
@@ -1,1 +1,1 @@
-%s\.<ret><a-space><a-space>i<ret><space><space><esc><gt>,q
+MLs\.<ret>i<ret><space><space><esc><gt>,q

--- a/58753af0f5ef5c0006000006/cmd
+++ b/58753af0f5ef5c0006000006/cmd
@@ -1,1 +1,1 @@
-%s\.<ret>aget('<esc>ea')<esc>,q
+%s\.<ret>aget('<a-;><a-w>')<esc>,q

--- a/591903ff3060ed0b32000007/cmd
+++ b/591903ff3060ed0b32000007/cmd
@@ -1,1 +1,1 @@
-%sno<ret>Wcbold<esc>f4;r2,q
+/4<ret>Nr2kbbcbold<esc>,q

--- a/59553bd164628d0009000038/cmd
+++ b/59553bd164628d0009000038/cmd
@@ -1,1 +1,1 @@
-5xyp4b*gehdhPby<a-/><ret>R,q
+5xyp4b*%hdhPby<a-n>R,q

--- a/5abb80fc40f4d919b6000002/cmd
+++ b/5abb80fc40f4d919b6000002/cmd
@@ -1,1 +1,1 @@
-9Cf<space>dwa-<space><esc>h&,q
+9C<a-w>dwa-<space><esc>h&,q

--- a/5b0ba8a4dd701305aeb59201/cmd
+++ b/5b0ba8a4dd701305aeb59201/cmd
@@ -1,1 +1,1 @@
-%|sort<space>-g<ret>,q
+%<a-s><a-o>BCi<c-r>#<space><esc>ggQ<a-i>nZ*ndzjQ999q%s\s+\H*$<ret>d,q

--- a/5b0ba8a4dd701305aeb59201/cmd
+++ b/5b0ba8a4dd701305aeb59201/cmd
@@ -1,1 +1,1 @@
-%<a-s><a-o>BCi<c-r>#<space><esc>ggQ<a-i>nZ*ndzjQ999q%s\s+\H*$<ret>d,q
+%<a-s><a-o>BCi<c-r>#<space><esc>ggQ<a-i>nZ*ndzjQ999q%s\s+$<ret>d,q

--- a/5b6e21c9a893790006232531/cmd
+++ b/5b6e21c9a893790006232531/cmd
@@ -1,1 +1,1 @@
-L*2N2wZf"<a-.><a-z>a<a-(>,q
+3w5C_Zf"<a-.><a-z>a<a-(>,q

--- a/5b71fa9105b5ca000ce4a7a1/cmd
+++ b/5b71fa9105b5ca000ce4a7a1/cmd
@@ -1,1 +1,1 @@
-5Ccprivate<space>String<esc>f:<a-l>c;<esc>,q
+4Ccprivate<space>String<esc><a-e><a-l>c;<esc>,q

--- a/5b9131545c53aa000ca952f6/cmd
+++ b/5b9131545c53aa000ca952f6/cmd
@@ -1,1 +1,1 @@
-l3C<a-l><a-k>l<ret>s..<ret>ykpj<a-x>d2<a-f>];r,<space>3bri,q
+QxxZs\w<ret>ykpa,<esc>zdQq6hri,q

--- a/5ba4962fbbac05000bc2ddec/cmd
+++ b/5ba4962fbbac05000bc2ddec/cmd
@@ -1,1 +1,1 @@
-3C2Ld`fsf<space>dwya<del><space>=<space>payload.<esc>p,q
+3C2Ld`fs<a-w>dwya<del><space>=<space>payload.<esc>p,q

--- a/5bff6e560d5dc0000ca3485b/cmd
+++ b/5bff6e560d5dc0000ca3485b/cmd
@@ -1,1 +1,1 @@
-9Cw&>L<a-S>i"<end>;<esc>2bHd<a-h>Ph&HdhPly2p,q
+9Cwd"#PB<a-;>&e<a-c><tab><space>"<c-r>"";<esc><a-f><tab>@<a-w>&,q

--- a/5c5f20c1e2dcab0009c10530/cmd
+++ b/5c5f20c1e2dcab0009c10530/cmd
@@ -1,1 +1,1 @@
-6Oa<space>=<space><c-r>#<esc>ghyQjpQ4q5<a-C><a-i>w&<c-d>xd,q
+ca<space>=<space><esc>QxyPghyPQ4q%<a-s>&h"#p,q

--- a/5c742a5a50bdf70006d43280/cmd
+++ b/5c742a5a50bdf70006d43280/cmd
@@ -1,1 +1,1 @@
-9lcwa<home>#<space><end><space>#<esc>hyl31pjxykP,q
+9lcwa<home>#<space><end><space>#<esc>xypHr#Lyjp,q

--- a/5c75b4246c2f8300092b8d97/cmd
+++ b/5c75b4246c2f8300092b8d97/cmd
@@ -1,1 +1,1 @@
-2eZhrn%s:<ret>ha*2<esc>|bc<ret><a-f><space>h<a-t>.<a-z>as.<ret>a<space><esc>,q
+eehrn%s:<ret>hZ<a-k>2<ret>r4z<a-k>3<ret>r6z5<space>r8z<a-k>6<ret>c12<esc>z7<space>c14<esc>z1<space>r2<a-f>i<a-z>a<a-f><space>h<a-h><a-W>s.<ret>a<space><esc>,q

--- a/5c75b4246c2f8300092b8d97/cmd
+++ b/5c75b4246c2f8300092b8d97/cmd
@@ -1,1 +1,1 @@
-eehrn%s:<ret>hZ<a-k>2<ret>r4z<a-k>3<ret>r6z5<space>r8z<a-k>6<ret>c12<esc>z7<space>c14<esc>z1<space>r2<a-f>i<a-z>a<a-f><space>h<a-h><a-W>s.<ret>a<space><esc>,q
+eehrn%s:<ret>hZy<a-k>2|7<ret>r42<space>Pz<a-k>3<ret>r6z5<space>r8z<a-k>6<ret>c12<esc>z1<space>r2<a-f>i<a-z>a<a-f><space>h<a-h><a-W>s.<ret>a<space><esc>,q

--- a/5c93945c9caf21000ca842f7/cmd
+++ b/5c93945c9caf21000ca842f7/cmd
@@ -1,1 +1,1 @@
-Q2f,lr<ret>Q6q%s'|,|<space><ret>d,q
+Q2f,;r<ret>Q6q%<a-s>Hs\W<ret>d,q

--- a/5cc31feaffd607000ccf6ea7/cmd
+++ b/5cc31feaffd607000ccf6ea7/cmd
@@ -1,1 +1,1 @@
-e*Nctable<esc>%sp<gt><ret>hctd<esc><gt>%sk<ret>O<space><space><lt>tr<gt><esc>3j.2bi/<esc>,q
+e*Nctable<esc>ww*7Nctd<esc><gt>%sk<ret>O<space><space><lt>tr<gt><esc>3j.2bi/<esc>,q

--- a/5d01c60354ee2200067df987/cmd
+++ b/5d01c60354ee2200067df987/cmd
@@ -1,1 +1,1 @@
-Qxs"<ret><a-)><a-space><a-space>djQ3q,q
+3Cf"l<a-l>s"<ret>d,q

--- a/5d745e799a72d600095eb7af/cmd
+++ b/5d745e799a72d600095eb7af/cmd
@@ -1,1 +1,1 @@
-%<a-s><a-k>mo<ret>d/bl<ret>Ec<c-n><esc>/or<space><ret>Na<backspace><ret><space><esc>l<gt><a-i>bs=+<ret>c===<esc>,q
+%smo<ret>xd/bl<ret>Ec<c-n><esc>/<space>r<ret>Ni<ret><esc><gt><a-C><a-w>ec===<esc>,q


### PR DESCRIPTION
Last ~~four~~ six commits replace pipes to external tools (`rev`,`sort`,`bc`) with native keystroke sequences. The last two updated challenges (5b0ba8a4dd701305aeb59201 and 5c75b4246c2f8300092b8d97) are not well suited for kakoune as it doesn't have internal arithmetic and sorting capabilities.