### PR TITLE
fix: corrected 504e43017890650002000019

### DIFF
--- a/504e43017890650002000019/cmd
+++ b/504e43017890650002000019/cmd
@@ -1,1 +1,1 @@
-rTxy17CR,q
+rTYVG18pZZ


### PR DESCRIPTION
Out of the box, the existing solution did almost nothing, and I
don't understand what it was trying to do with deleting a single
character before yanking. This change is a verified solution.

Also, I don't know how the original author gets away with the
remapped ,q as my remappings are disabled when I run vimgolf.

Regardless, ZZ is the same number of characters to write and quit
and you see ZZ in almost all of the top solutions for any
challenge.