### PR TITLE
More score improvements

### DIFF
--- a/4d1a1c36567bac34a9000002/cmd
+++ b/4d1a1c36567bac34a9000002/cmd
@@ -1,1 +1,1 @@
-j2JxddCdCdm,fdc.join(',')<esc>k<a-i>bc*a<esc><space>q
+j3JdCdCdm,fdc.join(',')<esc>k<a-i>bc*a<esc><space>q

--- a/4d1aaf2fb11838287d000036/cmd
+++ b/4d1aaf2fb11838287d000036/cmd
@@ -1,1 +1,1 @@
-<a-l>QZ<a-S><a-)>zHHQ12q<space>q
+<a-l>QHdpQ24q<space>q

--- a/4d1ac1800a045132c0000011/cmd
+++ b/4d1ac1800a045132c0000011/cmd
@@ -1,1 +1,1 @@
-<a-o>wa<space><esc>f)a<ret><esc>l.f;.<a-.><gt>.<space>q
+wa<ret><esc><a-j>m.m.l.f;.<a-.><gt>.<space>q

--- a/4d1cdb0635b40650b8000527/cmd
+++ b/4d1cdb0635b40650b8000527/cmd
@@ -1,1 +1,1 @@
-QxyP_Cr*,PQ4jq<space>q
+3e<a-*>Nx+y<a-S>lPHr*<space>q

--- a/4d1db1b8de2f897c2a00014a/cmd
+++ b/4d1db1b8de2f897c2a00014a/cmd
@@ -1,1 +1,1 @@
-fys.<ret>a<ret><esc><space>q
+<a-l>S.<ret>i<ret><esc><space>q

--- a/4d1e29fda93ce03311000066/cmd
+++ b/4d1e29fda93ce03311000066/cmd
@@ -1,1 +1,1 @@
-%s:<ret>dwER<space>q
+%s:<ret>deR<space>q

--- a/4d4ab047795d626036000034/cmd
+++ b/4d4ab047795d626036000034/cmd
@@ -1,1 +1,1 @@
-Q3Wy<a-l>s,<ret>r<ret>lRQ5gq<space>q
+C3E3+y<a-l>s,<ret>r<ret>lP<space>q

--- a/4d665abd7d73e02a55000009/cmd
+++ b/4d665abd7d73e02a55000009/cmd
@@ -1,1 +1,1 @@
-~iList<lt><esc>mc><esc><a-b>yAnew<space>Array<c-r>"();<esc>%s,<ret>Lc<ret><esc><a-C><a-&>xZ<a-K>\.<ret>Ad<a-;>z);<home>c.add(<esc>xdmx<a-R><space>q
+~iList<lt><esc>mc><esc><a-b>yAnew<space>Array<c-r>"();<esc>yms,<ret>LR<a-&><a-h>C<a-K>\.<ret>Ad<a-;><c-o>c.add(<end>);<esc>m<a-S>xd<space>q

--- a/4ddbd92898957e0001000016/cmd
+++ b/4ddbd92898957e0001000016/cmd
@@ -1,1 +1,1 @@
-11Jx<a-s>d%<a-s>p<space>q
+11Cxd%<a-s>p<space>q

--- a/4e31627b74ab580001000007/cmd
+++ b/4e31627b74ab580001000007/cmd
@@ -1,1 +1,1 @@
-m<a-b>*5Nd<a-f>fwcvoid<space><esc>b<a-*>,cdouble<space><esc>ndbyggxR<a-/>\$<ret>d2<a-n>d%s<ret>./s<ret>iMath.<esc>gjxd<space>q
+m<a-b>*5Nd<a-f>fecvoid<esc>B*,cdouble<space><esc>ndby%<a-S>x<a-d><a-,>P6w*3Nn.%s<ret>dtsaMath.<esc><space>q

--- a/4e9edef5cef4c50001000007/cmd
+++ b/4e9edef5cef4c50001000007/cmd
@@ -1,1 +1,1 @@
-ms\w+<ret>y%<a-d><a-P>i<ret>*|<end>|*<esc>ggd<space>q
+ms"<ret>r|<a-i>ud%<a-R>a*<ret><up>*<esc><c-o>d<space>q

--- a/4ef209ef78702b0001000019/cmd
+++ b/4ef209ef78702b0001000019/cmd
@@ -1,1 +1,1 @@
-%s# <ret>O<ret><esc><space>q
+%s#<space><ret>2<a-O><space>q

--- a/4fbf8e303be58b0001000024/cmd
+++ b/4fbf8e303be58b0001000024/cmd
@@ -1,1 +1,1 @@
-xs:<ret><a-f>VZ/\}<ret>N<a-z>ai<ret><up><esc>1<a-,>i<space><space><esc>x<a-k>E<ret>.x<a-_><a-,>jd<space>q
+xsV\S+:|\}<ret>i<ret><esc><a-,>i<space><space><esc>x<a-k>E<ret>.x<a-_><a-,>jd<space>q

--- a/4fcccb70024f950001000026/cmd
+++ b/4fcccb70024f950001000026/cmd
@@ -1,1 +1,1 @@
-ms\w+<ret><a-(><space>q
+mB<a-S>w<a-)><space>q

--- a/5035e5b3838d9e000200006d/cmd
+++ b/5035e5b3838d9e000200006d/cmd
@@ -1,1 +1,1 @@
-r<lt>A<gt><esc>%s"<ret>c<lt>td<gt><esc><a-i>byx_Rbi/<esc>,o<lt>/tr<gt><esc><space>q
+r<lt><a-l>a<gt><esc>y%phZ%s"<ret>Rhrd<a-i>bdx_R<a-z>abi/<esc><space>q

--- a/504e43017890650002000019/cmd
+++ b/504e43017890650002000019/cmd
@@ -1,1 +1,1 @@
-rTxy17CR<space>q
+rTxy%<a-s>R<space>q

--- a/50ad2cb165b8db0002000029/cmd
+++ b/50ad2cb165b8db0002000029/cmd
@@ -1,1 +1,1 @@
-%S\n\n<ret><a-j>s ><ret>d<space>q
+%<a-s>_x<a-_><a-j>s<space><gt><ret>d<space>q

--- a/50b1d7239aad89000200002d/cmd
+++ b/50b1d7239aad89000200002d/cmd
@@ -1,1 +1,1 @@
-jM<a-*>3Ney%<a-R>a|<esc>,I^(<end><backspace>).*$<esc><space>q
+jM*3Ne<a-*>%"/Ri^(<end>).*$<esc><space>q

--- a/50bda7a73645b3000200004b/cmd
+++ b/50bda7a73645b3000200004b/cmd
@@ -1,1 +1,1 @@
-e*4NdZ%sM<ret>PledzP<space>q
+e*4NZ%sM<ret>e<a-z>a2<a-)><space>q

--- a/51103ad8041832000200003f/cmd
+++ b/51103ad8041832000200003f/cmd
@@ -1,1 +1,1 @@
-O<space>v<space><down><right><ret><space>m<space><esc>%<a-s>Hd22P<end>;2<a-,>d%y6p<space>q
+O<space>v<space><down><right><ret><space>m<space><esc>%<a-s>Hy21p<a-i><space>d%y6p<space>q

--- a/521c805d860021000200007d/cmd
+++ b/521c805d860021000200007d/cmd
@@ -1,1 +1,1 @@
-QlwdQ11q<space>q
+xs\B<ret>Ld<space>q

--- a/53369b712a09c1000223fb57/cmd
+++ b/53369b712a09c1000223fb57/cmd
@@ -1,1 +1,1 @@
-t[a[2]<esc>o{<esc>hm>>lr,jt{dm>>a<ret>}<esc><space>q
+t{<a-m>yPldo{<esc><a-m>lr,j<a-.>dma<ret>}<esc>m<a-x><gt><gt><space>q

--- a/53eb4ac3f690b50002f871b6/cmd
+++ b/53eb4ac3f690b50002f871b6/cmd
@@ -1,1 +1,1 @@
-faaada<right><right>l<c-n><esc>md<space>q
+xsr..c<ret>d9ld<space>q

--- a/5421e49fdbded100021e4934/cmd
+++ b/5421e49fdbded100021e4934/cmd
@@ -1,1 +1,1 @@
-xys<space><ret>r<ret>ggxR<space>q
+w<a-l>yps<space><ret>r<ret><space>q

--- a/54345d14d529ef0002227d4c/cmd
+++ b/54345d14d529ef0002227d4c/cmd
@@ -1,1 +1,1 @@
-<a-O><c-d><a-i>bygg<a-P><a-j><space>q
+<a-O><c-d><a-i>by%<a-P><a-j><space>q

--- a/54698da795f6da00020d85ed/cmd
+++ b/54698da795f6da00020d85ed/cmd
@@ -1,1 +1,1 @@
-j<a-i>i<a-J>Ec,<esc><space>q
+m<a-x><a-J>Ec,<esc><space>q

--- a/54df95a4a4b28331e9000003/cmd
+++ b/54df95a4a4b28331e9000003/cmd
@@ -1,1 +1,1 @@
-%<a-s>2Hs.<ret>a<space><esc>..<space>q
+%<a-s>HS.<ret>i<space><esc>..<space>q

--- a/54f6e85d8dca0315e1010de1/cmd
+++ b/54f6e85d8dca0315e1010de1/cmd
@@ -1,1 +1,1 @@
-ms\w+<ret>y40l<a-c>:<space><esc>P3bhr<ret>j<gt><space>q
+%<a-t>gs<space><ret>i<ret>:<esc>wy<a-h>P<gt>4wd<space>q

--- a/5518cd2bfb03aa1d9402a6a3/cmd
+++ b/5518cd2bfb03aa1d9402a6a3/cmd
@@ -1,1 +1,1 @@
-/x<ret>NCmy<a-l>Zpzla/<esc><space>q
+jjm3CmLyA<lt>/<esc>P<space>q

--- a/55b18bbea9c2c30d04000001/cmd
+++ b/55b18bbea9c2c30d04000001/cmd
@@ -1,1 +1,1 @@
-5jxyphr1yp3hr73joNew t<c-n><c-n>.<ret><esc><space>q
+xyf0p3hc7<esc>lRpwo<ret>New<space>x<c-n>.<esc><space>q

--- a/55bcdc3ef4219f456102374f/cmd
+++ b/55bcdc3ef4219f456102374f/cmd
@@ -1,1 +1,1 @@
-xsb|l<ret>2E<a-)><space>q
+fxfg<a-S>BB<a-)><space>q

--- a/55f9720b4a665c2acf0008c8/cmd
+++ b/55f9720b4a665c2acf0008c8/cmd
@@ -1,1 +1,1 @@
-%<a-s>yP`s\W+<ret><a-K>$<ret>c-<end>:<down><home>name: "<end>"<esc><gt>gglrofé;reeldfï;rifâ;ra<space>q
+%<a-s>yP_`s\W+<ret>5<a-,>c-<end>:<right>name:<space>"<end>"<esc><gt><c-o>,hra6hrigglrof);d7hre<space>q

--- a/55ff7ea45a2b52043e06dee2/cmd
+++ b/55ff7ea45a2b52043e06dee2/cmd
@@ -1,1 +1,1 @@
-%sY_VAR_\w+<ret>`s_<ret>d~<space>q
+%sY_VAR_<ret>E`s_<ret>d~<space>q

--- a/56e69da07b3d84520a000001/cmd
+++ b/56e69da07b3d84520a000001/cmd
@@ -1,1 +1,1 @@
-<a-l>yZpzQZ<a-S><a-)>zHHQ14q<space>q
+<a-l>yPQHdpQ28q<space>q

--- a/57343555fd77ad227900df4a/cmd
+++ b/57343555fd77ad227900df4a/cmd
@@ -1,1 +1,1 @@
-MLs\.<ret>i<ret><space><space><esc><gt><space>q
+8w*NNi<ret><space><space><esc><gt><space>q

--- a/57786c012ec4a10d2e000001/cmd
+++ b/57786c012ec4a10d2e000001/cmd
@@ -1,1 +1,1 @@
-%S\n\n<ret>L<a-S>i"<esc><space>q
+%<a-s>_x<a-_><a-S>i"<esc><space>q

--- a/57cf3e398c660c1f8f014717/cmd
+++ b/57cf3e398c660c1f8f014717/cmd
@@ -1,1 +1,1 @@
-%saaa<ret>dp<space>q
+8lCCxdp<space>q

--- a/57d7d06d9ce5640f6f000001/cmd
+++ b/57d7d06d9ce5640f6f000001/cmd
@@ -1,1 +1,1 @@
-Q~2lQ3qj4qj4q<space>q
+*2<a-N><a-n>Q~2lQ3q<space>q

--- a/5853f052854f48716101cc70/cmd
+++ b/5853f052854f48716101cc70/cmd
@@ -1,1 +1,1 @@
-gebB<a-C>ykpkp<space>q
+%bB<a-C>ykpkp<space>q

--- a/587cab5a0740c90006000006/cmd
+++ b/587cab5a0740c90006000006/cmd
@@ -1,1 +1,1 @@
-Q<a-J>EdQjjq<space>q
+<a-*>Nn<a-J>Ed<space>q

--- a/587e0a9d5944680006000007/cmd
+++ b/587e0a9d5944680006000007/cmd
@@ -1,1 +1,1 @@
-<a-l>s.<ret>i[<esc>a]<esc>H`yP~<space>q
+w`s.<ret>yi[<esc>a]<esc>P~<space>q

--- a/58860440c57fb30006000004/cmd
+++ b/58860440c57fb30006000004/cmd
@@ -1,1 +1,1 @@
-fV;3Ct<lt>y<a-;>hi value="."<esc>2hR`s <ret>r_<space>q
+j3Ct/h<a-t><gt>yhPa"<esc>i<space>value="<esc>`s<space><ret>r_<space>q

--- a/59384eb3652ee111a0000001/cmd
+++ b/59384eb3652ee111a0000001/cmd
@@ -1,1 +1,1 @@
-3C4edBd<a-h>ZPzhr.<space>q
+3C4er.Bd<a-d><a-h>P<space>q

--- a/59553bd164628d0009000038/cmd
+++ b/59553bd164628d0009000038/cmd
@@ -1,1 +1,1 @@
-4jxyp4b*%hhdpby<a-n>R<space>q
+4jxyp4bcas<c-n><esc>%b.<space>q

--- a/5957c3356f7e17045b00002c/cmd
+++ b/5957c3356f7e17045b00002c/cmd
@@ -1,1 +1,1 @@
-%sFi<ret>ey<a-l>a<space>`xml:"f"`<esc>hP<space>q
+msF<ret>eyA<space>`x<c-n>:"<c-r>""`<esc><a-b>`<space>q

--- a/596dd9ca448256000c000011/cmd
+++ b/596dd9ca448256000c000011/cmd
@@ -1,1 +1,1 @@
-xs\d<ret>yjPa,<esc>kxd<space>q
+xs\d<ret>yjPa,<esc><c-o>d<space>q

--- a/5a0c38cd2e62f404f000001b/cmd
+++ b/5a0c38cd2e62f404f000001b/cmd
@@ -1,1 +1,1 @@
-xdp%s[A-O]<ret><a-l>d<a-h>P,fTwd<space>q
+xdpHs.<ret><a-)>k<a-)><a-)>jjd<space>q

--- a/5b6f0fcba89379000c2328a4/cmd
+++ b/5b6f0fcba89379000c2328a4/cmd
@@ -1,1 +1,1 @@
-%s_<ret>m<a-)><space>q
+*nN<a-m><a-)><space>q

--- a/5b9131545c53aa000ca952f6/cmd
+++ b/5b9131545c53aa000ca952f6/cmd
@@ -1,1 +1,1 @@
-QjxZs\w<ret>ykpi,<esc>zdQq6hri<space>q
+mCjxs\w<ret>ykpi,<esc>(,ri<c-o>d<space>q

--- a/5bf26adb9a198b0009ce0a87/cmd
+++ b/5bf26adb9a198b0009ce0a87/cmd
@@ -1,1 +1,1 @@
-5CfbwdhP&ghphPr<tab>y<a-.>2p<space>q
+5C<a-e>lyPLr<tab><a-h>Pr<tab>lpwp&<space>q

--- a/5c52df3ff6983b0006c69e80/cmd
+++ b/5c52df3ff6983b0006c69e80/cmd
@@ -1,1 +1,1 @@
-4C<a-l>d6jPa<space>"<end>"<esc>6kdd<space>q
+]p<a-s>d<a-.><a-s>P<a-J><a-l><a-S>a"<esc><space>q

--- a/5c5f20c1e2dcab0009c10530/cmd
+++ b/5c5f20c1e2dcab0009c10530/cmd
@@ -1,1 +1,1 @@
-ca<space>=<space><esc>QxypghyPQ4q%<a-s>&h"#p<space>q
+d5O<a-;>C<tab><space>=<space><c-r>#<esc><a-h>6@QhrajQ5q<space>q

--- a/5c742a5a50bdf70006d43280/cmd
+++ b/5c742a5a50bdf70006d43280/cmd
@@ -1,1 +1,1 @@
-9lcwa<home>#<space><end><space>#<esc>xypHr#LykP<space>q
+9lcwa<home>#<space><end><space>#<esc>xy<a-S>P*nHr#<space>q

--- a/5c75b4246c2f8300092b8d97/cmd
+++ b/5c75b4246c2f8300092b8d97/cmd
@@ -1,1 +1,1 @@
-eehrn%s:<ret>hZy<a-k>2|7<ret>r42,Pz<a-k>3<ret>r6z5,r8z<a-k>6<ret>c12<esc>z1,r2<a-f>i<a-z>a<a-f><space>h<a-h><a-W>s.<ret>a<space><esc><space>q
+6lrn%s:<ret>hZy<a-k>2|7<ret>r42,Pz<a-k>3<ret>r6z5,r8z<a-k>6<ret>c12<esc>z1,r2<a-f>i<a-z>a<a-f><space>h<a-h><a-W>s.<ret>a<space><esc><space>q

--- a/5d01c60354ee2200067df987/cmd
+++ b/5d01c60354ee2200067df987/cmd
@@ -1,1 +1,1 @@
-3Cf"l<a-l>s"<ret>d<space>q
+%<a-s>4<a-f>,s"<ret>d<space>q

--- a/5d745e799a72d600095eb7af/cmd
+++ b/5d745e799a72d600095eb7af/cmd
@@ -1,1 +1,1 @@
-%smo<ret>xd/bl<ret>Ec<c-n><esc>/<space>r<ret>Ni<ret><esc><gt><a-C><a-w>ec===<esc><space>q
+%smo<ret>xdfbe,c<c-n><esc>/<space>r<ret>Ni<ret><esc><gt><a-C><a-w>ec===<esc><space>q

--- a/9v00619554dd000000000216/cmd
+++ b/9v00619554dd000000000216/cmd
@@ -1,1 +1,1 @@
-Q9j<a-o>2jQ9q<space>q
+9J9C<a-o><space>q


### PR DESCRIPTION
Some just got slightly worse after the latest mass update changed `X` to `Jx` everywhere, but the old scores often could be restored by shuffling around the commands a bit.

Other small improvements could sometimes be achieved by employing rarely used commands like `<c-o>` to go back in the jump list instead of using the `Z` / `z` pair, or by `+` to duplicate selections ([and in one case](https://github.com/mawww/golf/tree/master/4d4ab047795d626036000034) , even `3+` to triplicate them). I tried to note their uses in commit messages.

[In another case](https://github.com/mawww/golf/tree/master/50b1d7239aad89000200002d), the `<a-*>` / `"/R` pair was used to construct a list of strings separated by vertical bars (`|`).