### PR TITLE
recognize <percent> as a single character

### DIFF
--- a/golf.sh
+++ b/golf.sh
@@ -4,7 +4,7 @@ shopt -s extglob
 
 count_keys() {
     local keys=$1
-    keys=${keys//<@([ca]-|)@(?|ret|space|tab|lt|gt|backspace|esc|up|down|left|right|pageup|pagedown|home|end|backtab|del|minus|plus|semicolon|space)>/0}
+    keys=${keys//<@([ca]-|)@(?|ret|space|tab|lt|gt|backspace|esc|up|down|left|right|pageup|pagedown|home|end|backtab|del|minus|plus|semicolon|space|percent)>/0}
     echo ${#keys}
 }
 


### PR DESCRIPTION
Found out that <percent> isn't recognized as a single character, but does appear when pasting from `@` after recording a macro.